### PR TITLE
CI: pin NSM to stable vl3 ver

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ e2e-kind-test: &e2e-kind-test
         name: Build vl3 runner container
         working_directory: /go/src/github.com/networkservicemesh/examples/examples/vl3_basic/ci/runner
         command: |
-          docker build --build-arg vl3_branch=${CIRCLE_SHA1:-master} -t vl3-runner:latest -f Dockerfile.runner .
+          docker build --build-arg vl3_branch=${CIRCLE_SHA1:-master} --build-arg nsm_branch=v0.2.0-vl3 -t vl3-runner:latest -f Dockerfile.runner .
 
     - run:
         name: Run vl3 test
@@ -73,7 +73,7 @@ jobs:
           command: |
             git clone https://github.com/tiswanso/networkservicemesh.git
             cd networkservicemesh
-            git checkout vl3_api_rebase
+            git checkout v0.2.0-vl3
       - run:
           name: Build docker images
           working_directory: /go/src/github.com/networkservicemesh/examples

--- a/examples/vl3_basic/ci/runner/Dockerfile.runner
+++ b/examples/vl3_basic/ci/runner/Dockerfile.runner
@@ -4,7 +4,7 @@ ARG  vl3_repo=https://github.com/tiswanso/examples.git
 # set this to branch or $CIRCLE_SHA1
 ARG  vl3_branch=master
 ARG  nsm_repo=https://github.com/tiswanso/networkservicemesh.git
-ARG  nsm_branch=vl3_api_rebase
+ARG  nsm_branch=vl3_latest
 
 RUN  git clone $vl3_repo /go/src/github.com/networkservicemesh/examples && \
      cd /go/src/github.com/networkservicemesh/examples && \


### PR DESCRIPTION
Move the runner container to pull tiswanso/networkservicemesh from the v0.2.0-vl3 tag