### PR TITLE
Vl3 latest IPAM validation fix

### DIFF
--- a/api/serviceregistry/helper.go
+++ b/api/serviceregistry/helper.go
@@ -62,7 +62,7 @@ func (m *Workload) Validate() error {
 	if err != nil {
 		errs = append(errs, err)
 	}
-	if len(m.IPAddress) > 1 {
+	if len(m.IPAddress) > 0 {
 		for _, s := range m.IPAddress {
 			_, err := toIpNet(s)
 			if err != nil {

--- a/api/serviceregistry/helper_test.go
+++ b/api/serviceregistry/helper_test.go
@@ -22,7 +22,6 @@ func Test(t *testing.T) {
 		Ports: []int32{1200, 1300},
 	}
 	err := svc.Validate()
-	fmt.Print(err)
 	if err != nil {
 		fmt.Print(err)
 		t.Fail()

--- a/api/serviceregistry/helper_test.go
+++ b/api/serviceregistry/helper_test.go
@@ -16,14 +16,15 @@ func Test(t *testing.T) {
 					PodName: "pod",
 					Name:    "workload",
 				},
-				IPAddress: []string{"127.0.0.1"},
+				IPAddress: []string{"172.100.220.1/24"},
 			},
 		},
 		Ports: []int32{1200, 1300},
 	}
 	err := svc.Validate()
+	fmt.Print(err)
 	if err != nil {
-		t.Fail()
 		fmt.Print(err)
+		t.Fail()
 	}
 }


### PR DESCRIPTION
IP validation fix.
Previous version: list must be at least 2 elements long to validate ip